### PR TITLE
Add CODE_OF_CONDUCT.md 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,104 @@
+# Code of Conduct for Interview.io 🎓🧑‍💻
+
+## 🌟 Our Pledge
+We as members, contributors, and leaders of **Interview.io** pledge to create a **safe, welcoming, and harassment-free environment** for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.  
+
+We promise to act with **kindness, respect, and integrity** in all interactions and contributions, helping to foster an **inclusive and supportive community** where everyone feels valued. 
+
+
+## 💬 Our Standards
+To ensure a positive and productive environment in **Interview.io**, contributors should:
+
+### ✅ Positive Behaviors
+- **Demonstrating empathy and kindness** toward other people
+- **Being respectful** of differing opinions, viewpoints, and experiences
+- **Giving and gracefully accepting** constructive feedback
+- **Accepting responsibility** and apologizing to those affected by our mistakes, and learning from the experience
+- **Focusing on what is best** not just for us as individuals, but for the overall community
+- **Using welcoming and inclusive language**
+- **Being patient with newcomers** and helping them learn
+- **Acknowledging contributions** from all community members
+
+### ❌ Unacceptable Behaviors
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Discrimination or hate speech based on protected characteristics
+- Intimidation or stalking
+- Spam or excessive self-promotion
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+
+## 🌐 Scope
+This Code of Conduct applies **everywhere contributors represent Interview.io**, including:
+
+- Repository spaces (issues, pull requests, code reviews)  
+- Public spaces when representing the project or community  
+- Events, online or offline, where participants act as project representatives  
+
+By following this code, everyone helps make **Interview.io a professional, fun, and welcoming community**! 🎉
+
+
+## ⚖️ Enforcement
+Project maintainers are responsible for enforcing the Code of Conduct. This may include:
+
+- Clarifying **acceptable standards of behavior**  
+- Taking **corrective action** for violations 
+- Temporary or permanent removal from project spaces for abusive or harmful behavior 
+
+Maintainers are committed to **fair, transparent, and consistent enforcement**, ensuring all contributors feel safe and supported.
+
+## Enforcement Process 🔍
+
+### Reporting
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at:
+
+- **Email**: [maintainer@example.com] (to be updated by maintainers) 
+- **GitHub Issues**: For public concerns that don't involve personal conflicts
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+### Investigation
+All community leaders are obligated to respect **privacy and security** of the reporter of any incident.
+
+### Enforcement Guidelines
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+#### 1. Correction 📝
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+#### 2. Warning ⚠️
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+#### 3. Temporary Ban 🚫
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+#### 4. Permanent Ban 🔒
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Appeals Process 📋
+
+If you believe you have been falsely or unfairly accused of violating this Code of Conduct, you should notify the project maintainers with a concise description of your grievance. Appeals will be handled fairly and promptly.
+
+## Recognition 🏆
+
+We believe in recognizing positive behavior and contributions to our community. Contributors who consistently embody our values may be recognized through:
+
+- Public acknowledgment in releases and documentation
+- Invitation to join the maintainer team
+- Speaking opportunities at events
+- Other forms of community recognition
+
+
+## 🏆 Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available [here](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+


### PR DESCRIPTION
This PR adds a CODE_OF_CONDUCT.md file to Interview.io, following the Contributor Covenant v2.1 template. 

It defines:

- Expected contributor behavior and unacceptable actions
- Reporting guidelines via maintainer email (maintainer should added before merge)
- Scope and enforcement of the code

Closes #1

 If there are any updates, corrections, or revisions needed for this Code of Conduct, please feel free to suggest them. I am happy to make any necessary adjustments to ensure it aligns perfectly with the project’s standards and expectations.
